### PR TITLE
tag parenting deletes

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -771,7 +771,7 @@ pub const Context = struct {
                     hash_data: sqlite.Blob,
                     tag_source_type: i64,
                     tag_source_id: i64,
-                    parent_source_id: i64,
+                    parent_source_id: ?i64,
                 },
                 allocator,
                 .{},

--- a/src/tags_main.zig
+++ b/src/tags_main.zig
@@ -914,7 +914,7 @@ const RemoveParent = struct {
 };
 
 test "remove parent (no entry deletion)" {
-    var ctx = try manage_main.makeTestContextRealFile();
+    var ctx = try manage_main.makeTestContext();
     defer ctx.deinit();
 
     var tmp = std.testing.tmpDir(.{});
@@ -1027,6 +1027,12 @@ test "remove parent (with entry deletion)" {
     var file_tags = try indexed_file.fetchTags(std.testing.allocator);
     defer std.testing.allocator.free(file_tags);
     try std.testing.expectEqual(@as(usize, 3), file_tags.len);
+
+    for (file_tags) |file_tag| {
+        if (file_tag.core.id == ids.parent_tag_core_id) {
+            return error.ShouldNotFindOriginalParentIdHere;
+        }
+    }
 }
 
 const CreatePool = struct {


### PR DESCRIPTION
by default, preserve all tag entries (but remove the `parent_source_id` relationship) unless `--delete-tag-file-entries` is given to `atags parent remove`.

close #23.