### PR TITLE
Link GraphicsMagick headers in macOS

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 //const deps = @import("deps.zig");
 
 const EXECUTABLES = .{
@@ -16,8 +17,22 @@ const EXECUTABLES = .{
 
 fn addGraphicsMagick(thing: anytype) void {
     thing.linkLibC();
-    thing.addIncludePath(.{ .cwd_relative = "/usr/include" });
-    thing.addIncludePath(.{ .cwd_relative = "/usr/include/GraphicsMagick" });
+
+    const arch = builtin.target.cpu.arch;
+    const target = builtin.target;
+    const include: []const u8 = "/usr/include";
+    var gm: []const u8 = "/usr/include/GraphicsMagick";
+
+    if (std.Target.isDarwin(target)) {
+        gm = switch (arch) {
+            .x86 => "/usr/local/include/GraphicsMagick",
+            .aarch64 => "/opt/homebrew/include/GraphicsMagick",
+            else => {},
+        };
+    }
+
+    thing.addIncludePath(.{ .cwd_relative = include });
+    thing.addIncludePath(.{ .cwd_relative = gm });
 }
 
 pub fn build(b: *std.Build) !void {


### PR DESCRIPTION
Not ready yet, intended to fix #68 

Before, `build.zig` was using `-I /usr/include -I /usr/include/GraphicsMagick`. Changes try to grab the appropriate headers on macOS.

This change considers Homebrew only. To add support MacPorts we'll likely have to look under `/opt/local`.