### PR TITLE
capture stdout from atags and FINALLY re-enable ci because of that

### DIFF
--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -13,6 +13,7 @@ jobs:
       # TODO crosscompile testing: https://github.com/lun-4/awtfdb/issues/1
       # TODO crosscompile testing: https://github.com/lun-4/awtfdb/issues/2
       - run: zig build
+      - run: zig build test
       - run: ci/smoketest.sh
   test-awtfdb-macos:
     runs-on: macos-latest
@@ -27,4 +28,5 @@ jobs:
           brew unlink gettext && brew link gettext --force
       - run: zig build build-test-only -freference-trace --verbose --verbose-link --verbose-cc
       - run: zig build
+      - run: zig build test
       - run: ci/smoketest.sh

--- a/src/main.zig
+++ b/src/main.zig
@@ -2174,6 +2174,7 @@ pub fn makeTestContextWithOptions(options: MakeTestContextOptions) !Context {
         .db = db,
     };
 
+    logger.warn("==TEST CTX CREATED", .{});
     if (options.load_migrations) {
         try migrateCommand(undefined, &ctx);
     }
@@ -2204,6 +2205,7 @@ pub fn makeTestContextRealFileWithOptions(options: MakeTestContextOptions) !Cont
         .db_path = try std.testing.allocator.dupe(u8, dbpath),
     });
 
+    logger.warn("==TEST CTX CREATED. REAL FILE: {s}", .{dbpath});
     if (options.load_migrations) try migrateCommand(undefined, &ctx);
     return ctx;
 }

--- a/src/tags_main.zig
+++ b/src/tags_main.zig
@@ -68,25 +68,33 @@ const ActionConfig = union(enum) {
     RemoveSource: RemoveSource.Config,
 };
 
+const BufferedStdout = std.io.BufferedWriter(4096, std.fs.File.Writer);
+
 const IOContext = struct {
-    stdout: std.io.BufferedWriter(4096, std.fs.File.Writer).Writer,
+    buffered_stdout: BufferedStdout,
     const Self = @This();
 
     pub fn system() Self {
         const raw_stdout = std.io.getStdOut().writer();
-        const BufferedFileWriter = std.io.BufferedWriter(4096, std.fs.File.Writer);
-        var buffered_stdout = BufferedFileWriter{ .unbuffered_writer = raw_stdout };
+        const buffered_stdout = BufferedStdout{ .unbuffered_writer = raw_stdout };
         return Self{
-            .stdout = buffered_stdout.writer(),
+            .buffered_stdout = buffered_stdout,
         };
     }
 
     pub fn captured(target_fd: std.fs.File.Writer) Self {
-        const BufferedFileWriter = std.io.BufferedWriter(4096, std.fs.File.Writer);
-        var buffered = BufferedFileWriter{ .unbuffered_writer = target_fd };
+        const buffered = BufferedStdout{ .unbuffered_writer = target_fd };
         return Self{
-            .stdout = buffered.writer(),
+            .buffered_stdout = buffered,
         };
+    }
+
+    pub fn stdout(self: *Self) BufferedStdout.Writer {
+        return self.buffered_stdout.writer();
+    }
+
+    pub fn flushStdout(self: *Self) !void {
+        try self.buffered_stdout.flush();
     }
 };
 
@@ -128,11 +136,11 @@ const CreateAction = struct {
 
     ctx: *Context,
     config: Config,
-    io: IOContext,
+    io: *IOContext,
 
     const Self = @This();
 
-    pub fn init(ctx: *Context, config: Config, io: IOContext) !Self {
+    pub fn init(ctx: *Context, config: Config, io: *IOContext) !Self {
         return Self{ .ctx = ctx, .config = config, .io = io };
     }
 
@@ -221,9 +229,9 @@ const CreateAction = struct {
                 defer file.deinit();
                 try file.addTag(tag_to_be_aliased_to, .{});
 
-                try self.io.stdout.print("relinked {s}", .{file.local_path});
-                try file.printTagsTo(self.ctx.allocator, self.io.stdout, .{});
-                try self.io.stdout.print("\n", .{});
+                try self.io.stdout().print("relinked {s}", .{file.local_path});
+                try file.printTagsTo(self.ctx.allocator, self.io.stdout(), .{});
+                try self.io.stdout().print("\n", .{});
             }
 
             // delete tag_to_be_aliased_from
@@ -239,21 +247,23 @@ const CreateAction = struct {
 
         const tag = try self.ctx.createNamedTag(self.config.tag.?, "en", maybe_core, .{});
 
-        try self.io.stdout.print(
+        try self.io.stdout().print(
             "created tag with core '{s}' name '{s}'\n",
             .{ tag.core, tag },
         );
     }
 };
 
-fn testIO() !struct {
+const TestIO = struct {
     f: std.fs.File,
     io: IOContext,
 
     pub fn deinit(self: @This()) void {
         self.f.close();
     }
-} {
+};
+
+fn testIO() !TestIO {
     var tmp = std.testing.tmpDir(.{});
     // dont care about cleaning tmp
 
@@ -271,11 +281,13 @@ test "create action" {
     var ctx = try manage_main.makeTestContext();
     defer ctx.deinit();
 
-    const tio = try testIO();
+    var tio = try testIO();
     defer tio.deinit();
 
-    var action = try CreateAction.init(&ctx, config, tio.io);
+    var action = try CreateAction.init(&ctx, config, &tio.io);
     defer action.deinit();
+
+    try (&tio.io).stdout().print("test!!\n", .{});
 
     try action.run();
 
@@ -300,10 +312,10 @@ test "create action (aliasing)" {
         .tag = "test tag2",
     };
 
-    const tio = try testIO();
+    var tio = try testIO();
     defer tio.deinit();
 
-    var action = try CreateAction.init(&ctx, config, tio.io);
+    var action = try CreateAction.init(&ctx, config, &tio.io);
     defer action.deinit();
 
     try action.run();
@@ -381,11 +393,12 @@ const RemoveAction = struct {
 
     ctx: *Context,
     config: Config,
+    io: *IOContext,
 
     const Self = @This();
 
-    pub fn init(ctx: *Context, config: Config) !Self {
-        return Self{ .ctx = ctx, .config = config };
+    pub fn init(ctx: *Context, config: Config, io: *IOContext) !Self {
+        return Self{ .ctx = ctx, .config = config, .io = io };
     }
 
     pub fn deinit(self: *Self) void {
@@ -393,13 +406,11 @@ const RemoveAction = struct {
     }
 
     pub fn run(self: *Self) !void {
-        var stdout = std.io.getStdOut().writer();
-
         var raw_core_hash_buffer: [32]u8 = undefined;
 
         var amount: usize = 0;
         var core_hash_id: ?ID = null;
-        try stdout.print("the following tags will be removed:\n", .{});
+        try self.io.stdout().print("the following tags will be removed:\n", .{});
 
         if (self.config.tag_core) |tag_core_hex_string| {
             var core = try consumeCoreHash(self.ctx, &raw_core_hash_buffer, tag_core_hex_string);
@@ -430,20 +441,20 @@ const RemoveAction = struct {
                     self.ctx.allocator.free(tag_name.tag_text);
                     self.ctx.allocator.free(tag_name.tag_language);
                 }
-                try stdout.print(" {s}", .{tag_name.tag_text});
+                try self.io.stdout().print(" {s}", .{tag_name.tag_text});
                 amount += 1;
             }
-            try stdout.print("\n", .{});
+            try self.io.stdout().print("\n", .{});
         } else if (self.config.tag) |tag_text| {
             const maybe_tag = try self.ctx.fetchNamedTag(tag_text, "en");
             if (maybe_tag) |tag| {
-                try stdout.print(" {s}", .{tag.kind.Named.text});
+                try self.io.stdout().print(" {s}", .{tag.kind.Named.text});
                 core_hash_id = tag.core.id;
                 amount += 1;
             } else {
                 return error.NamedTagNotFound;
             }
-            try stdout.print("\n", .{});
+            try self.io.stdout().print("\n", .{});
         } else if (self.config.only_tag_name) |only_tag_name| {
             // only delete a singular tag name. do not delete any files.
             // tag core will be garbage collected in a janitor run
@@ -486,7 +497,7 @@ const RemoveAction = struct {
                 .{},
                 .{core_hash_id.?.sql()},
             )) orelse 0;
-            try stdout.print("{d} files reference this tag.\n", .{referenced_files});
+            try self.io.stdout().print("{d} files reference this tag.\n", .{referenced_files});
         }
 
         try self.config.given_args.maybeAskConfirmation(
@@ -529,13 +540,16 @@ const RemoveAction = struct {
                 .{ tag_text, "en", tag_text, "en" },
             )).?;
         }
-        try stdout.print("deleted {d} tags\n", .{deleted_count.?});
+        try self.io.stdout().print("deleted {d} tags\n", .{deleted_count.?});
     }
 };
 
 test "remove action" {
     var ctx = try manage_main.makeTestContext();
     defer ctx.deinit();
+
+    var tio = try testIO();
+    defer tio.deinit();
 
     var tag = try ctx.createNamedTag("test tag", "en", null, .{});
     const tag2 = try ctx.createNamedTag("test tag2", "en", tag.core, .{});
@@ -563,8 +577,10 @@ test "remove action" {
         .given_args = &args,
     };
 
-    var action = try RemoveAction.init(&ctx, config);
+    var action = try RemoveAction.init(&ctx, config, &tio.io);
     defer action.deinit();
+
+    try (&tio.io).stdout().print("HIIII\n", .{});
 
     try action.run();
 
@@ -609,11 +625,12 @@ const SearchAction = struct {
 
     ctx: *Context,
     config: Config,
+    io: *IOContext,
 
     const Self = @This();
 
-    pub fn init(ctx: *Context, config: Config) !Self {
-        return Self{ .ctx = ctx, .config = config };
+    pub fn init(ctx: *Context, config: Config, io: *IOContext) !Self {
+        return Self{ .ctx = ctx, .config = config, .io = io };
     }
 
     pub fn deinit(self: *Self) void {
@@ -621,8 +638,6 @@ const SearchAction = struct {
     }
 
     pub fn run(self: *Self) !void {
-        var stdout = std.io.getStdOut().writer();
-
         var stmt = if (self.config.exact)
             try self.ctx.db.prepareDynamic(
                 \\ select distinct core_hash core_hash, hashes.hash_data
@@ -675,14 +690,14 @@ const SearchAction = struct {
 
             const full_tag_core = related_tags.items[0].core;
             if (self.config.show_hashes) {
-                try stdout.print("{s}", .{fake_hash.toRealHash()});
+                try self.io.stdout().print("{s}", .{fake_hash.toRealHash()});
             } else {
-                try stdout.print("{s}", .{full_tag_core.id});
+                try self.io.stdout().print("{s}", .{full_tag_core.id});
             }
             for (related_tags.items) |tag| {
-                try stdout.print(" '{s}'", .{tag});
+                try self.io.stdout().print(" '{s}'", .{tag});
             }
-            try stdout.print("\n", .{});
+            try self.io.stdout().print("\n", .{});
         }
     }
 };
@@ -727,11 +742,12 @@ const CreateParent = struct {
 
     ctx: *Context,
     config: Config,
+    io: *IOContext,
 
     const Self = @This();
 
-    pub fn init(ctx: *Context, config: Config) !Self {
-        return Self{ .ctx = ctx, .config = config };
+    pub fn init(ctx: *Context, config: Config, io: *IOContext) !Self {
+        return Self{ .ctx = ctx, .config = config, .io = io };
     }
 
     pub fn deinit(self: *Self) void {
@@ -739,7 +755,6 @@ const CreateParent = struct {
     }
 
     pub fn run(self: *Self) !void {
-        var stdout = std.io.getStdOut().writer();
         const child_tag = (try self.ctx.fetchNamedTag(self.config.child_tag.?, "en")) orelse {
             logger.err("expected '{s}' to be a named tag", .{self.config.child_tag.?});
             return error.ChildTagNotFound;
@@ -750,7 +765,7 @@ const CreateParent = struct {
         };
 
         const tree_id = try self.ctx.createTagParent(child_tag, parent_tag);
-        try stdout.print(
+        try self.io.stdout().print(
             "created tag parent where every file with '{s}' is also '{s}' (tree id {d})\nprocessing new parents...\n",
             .{ child_tag, parent_tag, tree_id },
         );
@@ -770,12 +785,13 @@ const ListParent = struct {
 
     ctx: *Context,
     config: void,
+    io: *IOContext,
 
     const Self = @This();
 
-    pub fn init(ctx: *Context, config: void) !Self {
+    pub fn init(ctx: *Context, config: void, io: *IOContext) !Self {
         _ = config;
-        return Self{ .ctx = ctx, .config = {} };
+        return Self{ .ctx = ctx, .config = {}, .io = io };
     }
 
     pub fn deinit(self: *Self) void {
@@ -783,8 +799,6 @@ const ListParent = struct {
     }
 
     pub fn run(self: *Self) !void {
-        const raw_stdout = std.io.getStdOut().writer();
-
         var stmt = try self.ctx.db.prepare(
             \\ select rowid,
             \\  parent_tag,
@@ -809,12 +823,8 @@ const ListParent = struct {
             self.ctx.allocator.free(entries);
         }
 
-        const BufferedFileWriter = std.io.BufferedWriter(4096, std.fs.File.Writer);
-        var buffered_stdout = BufferedFileWriter{ .unbuffered_writer = raw_stdout };
-        var stdout = buffered_stdout.writer();
-
         for (entries) |tree_row| {
-            try stdout.print(
+            try self.io.stdout().print(
                 "{d}: {d} {s} -> {d} {s}\n",
                 .{
                     tree_row.rowid,
@@ -826,7 +836,7 @@ const ListParent = struct {
             );
         }
 
-        try buffered_stdout.flush();
+        try self.io.flushStdout();
     }
 };
 
@@ -855,11 +865,12 @@ const RemoveParent = struct {
 
     ctx: *Context,
     config: Config,
+    io: *IOContext,
 
     const Self = @This();
 
-    pub fn init(ctx: *Context, config: Config) !Self {
-        return Self{ .ctx = ctx, .config = config };
+    pub fn init(ctx: *Context, config: Config, io: *IOContext) !Self {
+        return Self{ .ctx = ctx, .config = config, .io = io };
     }
 
     pub fn deinit(self: *Self) void {
@@ -867,9 +878,7 @@ const RemoveParent = struct {
     }
 
     pub fn run(self: *Self) !void {
-        var stdout = std.io.getStdOut().writer();
-
-        // parent_relationship is only used on that stdout call as
+        // parent_relationship is only used on that stdout) call as
         // information for the user, so it can't be tested until we have
         // stdout capturing.
         const parent_relationship = (try self.ctx.db.one(
@@ -879,7 +888,7 @@ const RemoveParent = struct {
             .{self.config.rowid.?},
         )) orelse return error.InvalidParentId;
 
-        try stdout.print(
+        try self.io.stdout().print(
             "the parent relationship is between tags {s} -> {s}\n",
             .{ parent_relationship.parent_tag, parent_relationship.child_tag },
         );
@@ -892,9 +901,9 @@ const RemoveParent = struct {
         )).?;
 
         if (self.config.delete_file_entries) {
-            try stdout.print("tag entries in files that were made by this relationship will be removed ({d} entries)\n", .{tag_file_count});
+            try self.io.stdout().print("tag entries in files that were made by this relationship will be removed ({d} entries)\n", .{tag_file_count});
         } else {
-            try stdout.print("tag entries in files that were made by this relationship will be retained but their relationship metadata will be removed. ({d} entries)\n", .{tag_file_count});
+            try self.io.stdout().print("tag entries in files that were made by this relationship will be retained but their relationship metadata will be removed. ({d} entries)\n", .{tag_file_count});
         }
 
         try self.config.given_args.maybeAskConfirmation(
@@ -968,13 +977,16 @@ const RemoveParent = struct {
             );
         }
 
-        try stdout.print("deleted parent id {d}\n", .{self.config.rowid.?});
+        try self.io.stdout().print("deleted parent id {d}\n", .{self.config.rowid.?});
     }
 };
 
 test "remove parent (no entry deletion)" {
     var ctx = try manage_main.makeTestContext();
     defer ctx.deinit();
+
+    var tio = try testIO();
+    defer tio.deinit();
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -985,7 +997,7 @@ test "remove parent (no entry deletion)" {
     var indexed_file = try ctx.createFileFromDir(tmp.dir, "test_file", .{});
     defer indexed_file.deinit();
 
-    const ids = try parentTestSetup(&ctx, &indexed_file);
+    const ids = try parentTestSetup(&ctx, &indexed_file, &tio.io);
 
     // attempt to run command with delete_file_entries = false
 
@@ -997,7 +1009,7 @@ test "remove parent (no entry deletion)" {
         .delete_file_entries = false,
     };
 
-    var action = try RemoveParent.init(&ctx, config);
+    var action = try RemoveParent.init(&ctx, config, &tio.io);
     defer action.deinit();
 
     try action.run();
@@ -1031,6 +1043,7 @@ const ParentTestSetupResult = struct {
 fn parentTestSetup(
     ctx: *Context,
     indexed_file: *Context.File,
+    io: *IOContext,
 ) !ParentTestSetupResult {
     const child_tag = try ctx.createNamedTag("child_test_tag", "en", null, .{});
     try indexed_file.addTag(child_tag.core, .{});
@@ -1048,7 +1061,7 @@ fn parentTestSetup(
 
     // always run ListParent so that it compiles
     // TODO write test for ListParent (capture stdout??)
-    var action = try ListParent.init(ctx, {});
+    var action = try ListParent.init(ctx, {}, io);
     defer action.deinit();
     try action.run();
 
@@ -1065,6 +1078,8 @@ fn parentTestSetup(
 test "remove parent (with entry deletion)" {
     var ctx = try manage_main.makeTestContext();
     defer ctx.deinit();
+    var tio = try testIO();
+    defer tio.deinit();
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -1075,7 +1090,7 @@ test "remove parent (with entry deletion)" {
     var indexed_file = try ctx.createFileFromDir(tmp.dir, "test_file", .{});
     defer indexed_file.deinit();
 
-    const ids = try parentTestSetup(&ctx, &indexed_file);
+    const ids = try parentTestSetup(&ctx, &indexed_file, &tio.io);
 
     var args = Args{ .ask_confirmation = false };
     const config = RemoveParent.Config{
@@ -1085,7 +1100,7 @@ test "remove parent (with entry deletion)" {
         .delete_file_entries = true,
     };
 
-    var action = try RemoveParent.init(&ctx, config);
+    var action = try RemoveParent.init(&ctx, config, &tio.io);
     defer action.deinit();
 
     try action.run();
@@ -1562,37 +1577,37 @@ pub fn main() anyerror!void {
     defer ctx.deinit();
     if (given_args.dry_run) try ctx.turnIntoMemoryDb();
 
-    const default_io = IOContext.system();
+    var default_io = IOContext.system();
 
     errdefer ctx.logLastError();
     switch (action_config) {
         .Search => |search_config| {
-            var self = try SearchAction.init(&ctx, search_config);
+            var self = try SearchAction.init(&ctx, search_config, &default_io);
             defer self.deinit();
             try self.run();
         },
         .Create => |create_config| {
-            var self = try CreateAction.init(&ctx, create_config, default_io);
+            var self = try CreateAction.init(&ctx, create_config, &default_io);
             defer self.deinit();
             try self.run();
         },
         .Remove => |remove_config| {
-            var self = try RemoveAction.init(&ctx, remove_config);
+            var self = try RemoveAction.init(&ctx, remove_config, &default_io);
             defer self.deinit();
             try self.run();
         },
         .CreateParent => |config| {
-            var self = try CreateParent.init(&ctx, config);
+            var self = try CreateParent.init(&ctx, config, &default_io);
             defer self.deinit();
             try self.run();
         },
         .ListParent => |config| {
-            var self = try ListParent.init(&ctx, config);
+            var self = try ListParent.init(&ctx, config, &default_io);
             defer self.deinit();
             try self.run();
         },
         .RemoveParent => |config| {
-            var self = try RemoveParent.init(&ctx, config);
+            var self = try RemoveParent.init(&ctx, config, &default_io);
             defer self.deinit();
             try self.run();
         },

--- a/src/tags_main.zig
+++ b/src/tags_main.zig
@@ -72,6 +72,7 @@ const BufferedStdout = std.io.BufferedWriter(4096, std.fs.File.Writer);
 
 const IOContext = struct {
     buffered_stdout: BufferedStdout,
+    unbuffered_stdout: std.fs.File.Writer,
     const Self = @This();
 
     pub fn system() Self {
@@ -79,6 +80,7 @@ const IOContext = struct {
         const buffered_stdout = BufferedStdout{ .unbuffered_writer = raw_stdout };
         return Self{
             .buffered_stdout = buffered_stdout,
+            .unbuffered_stdout = raw_stdout,
         };
     }
 
@@ -86,10 +88,16 @@ const IOContext = struct {
         const buffered = BufferedStdout{ .unbuffered_writer = target_fd };
         return Self{
             .buffered_stdout = buffered,
+            .unbuffered_stdout = target_fd,
         };
     }
 
-    pub fn stdout(self: *Self) BufferedStdout.Writer {
+    pub fn stdout(self: *Self) std.fs.File.Writer {
+        return self.unbuffered_stdout;
+    }
+
+    /// Must use flushStdout afterwards.
+    pub fn bufferedStdout(self: *Self) BufferedStdout.Writer {
         return self.buffered_stdout.writer();
     }
 
@@ -265,9 +273,12 @@ const TestIO = struct {
 
 fn testIO() !TestIO {
     var tmp = std.testing.tmpDir(.{});
-    // dont care about cleaning tmp
+    // dont want to clean tmp -- has debug info
 
     const file = try tmp.dir.createFile("captured.txt", .{ .read = true });
+    var realpath_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const realpath = tmp.dir.realpath("captured.txt", &realpath_buf) catch unreachable;
+    std.debug.print("realpath = {s}\n", .{realpath});
     const io = IOContext.captured(file.writer());
     return .{ .f = file, .io = io };
 }
@@ -1059,8 +1070,7 @@ fn parentTestSetup(
     const tag_tree_entry3_id = try ctx.createTagParent(parent_tag2, parent_tag3);
     try ctx.processTagTree(.{});
 
-    // always run ListParent so that it compiles
-    // TODO write test for ListParent (capture stdout from test io)
+    // always run ListParent to ensure that tag parenting worked
     var action = try ListParent.init(ctx, {}, &tio.io);
     defer action.deinit();
     try action.run();
@@ -1112,6 +1122,16 @@ test "remove parent (with entry deletion)" {
     defer action.deinit();
 
     try action.run();
+
+    {
+        try tio.f.seekTo(0);
+        var buf: [8192]u8 = undefined;
+        const bytes = try tio.f.readAll(&buf);
+        const stdout_sent = buf[0..bytes];
+        try std.testing.expect(bytes > 0);
+        try std.testing.expect(std.mem.containsAtLeast(u8, stdout_sent, 1, "the parent relationship is between tags"));
+        try std.testing.expect(std.mem.containsAtLeast(u8, stdout_sent, 1, ids.parent_tag_core_id.str()));
+    }
 
     const file_tags = try indexed_file.fetchTags(std.testing.allocator);
     defer std.testing.allocator.free(file_tags);
@@ -1417,7 +1437,7 @@ const ListSource = struct {
         }
 
         for (entries) |row| {
-            try self.io.stdout().print(
+            try self.io.bufferedStdout().print(
                 "type={d} id={d}: name={s}\n",
                 .{ row.type, row.id, row.name },
             );

--- a/src/tags_main.zig
+++ b/src/tags_main.zig
@@ -68,6 +68,28 @@ const ActionConfig = union(enum) {
     RemoveSource: RemoveSource.Config,
 };
 
+const IOContext = struct {
+    stdout: std.io.BufferedWriter(4096, std.fs.File.Writer).Writer,
+    const Self = @This();
+
+    pub fn system() Self {
+        const raw_stdout = std.io.getStdOut().writer();
+        const BufferedFileWriter = std.io.BufferedWriter(4096, std.fs.File.Writer);
+        var buffered_stdout = BufferedFileWriter{ .unbuffered_writer = raw_stdout };
+        return Self{
+            .stdout = buffered_stdout.writer(),
+        };
+    }
+
+    pub fn captured(target_fd: std.fs.File.Writer) Self {
+        const BufferedFileWriter = std.io.BufferedWriter(4096, std.fs.File.Writer);
+        var buffered = BufferedFileWriter{ .unbuffered_writer = target_fd };
+        return Self{
+            .stdout = buffered.writer(),
+        };
+    }
+};
+
 const CreateAction = struct {
     pub const Config = struct {
         tag_core: ?[]const u8 = null,
@@ -106,11 +128,12 @@ const CreateAction = struct {
 
     ctx: *Context,
     config: Config,
+    io: IOContext,
 
     const Self = @This();
 
-    pub fn init(ctx: *Context, config: Config) !Self {
-        return Self{ .ctx = ctx, .config = config };
+    pub fn init(ctx: *Context, config: Config, io: IOContext) !Self {
+        return Self{ .ctx = ctx, .config = config, .io = io };
     }
 
     pub fn deinit(self: *Self) void {
@@ -118,10 +141,6 @@ const CreateAction = struct {
     }
 
     pub fn run(self: *Self) !void {
-        const unbuffered_stdout = std.io.getStdOut().writer();
-        var buffered_stream = std.io.bufferedWriter(unbuffered_stdout);
-        var stdout = buffered_stream.writer();
-
         var raw_core_hash_buffer: [32]u8 = undefined;
         var maybe_core: ?Context.Hash = null;
 
@@ -202,9 +221,9 @@ const CreateAction = struct {
                 defer file.deinit();
                 try file.addTag(tag_to_be_aliased_to, .{});
 
-                try stdout.print("relinked {s}", .{file.local_path});
-                try file.printTagsTo(self.ctx.allocator, stdout, .{});
-                try stdout.print("\n", .{});
+                try self.io.stdout.print("relinked {s}", .{file.local_path});
+                try file.printTagsTo(self.ctx.allocator, self.io.stdout, .{});
+                try self.io.stdout.print("\n", .{});
             }
 
             // delete tag_to_be_aliased_from
@@ -220,12 +239,28 @@ const CreateAction = struct {
 
         const tag = try self.ctx.createNamedTag(self.config.tag.?, "en", maybe_core, .{});
 
-        try stdout.print(
+        try self.io.stdout.print(
             "created tag with core '{s}' name '{s}'\n",
             .{ tag.core, tag },
         );
     }
 };
+
+fn testIO() !struct {
+    f: std.fs.File,
+    io: IOContext,
+
+    pub fn deinit(self: @This()) void {
+        self.f.close();
+    }
+} {
+    var tmp = std.testing.tmpDir(.{});
+    // dont care about cleaning tmp
+
+    const file = try tmp.dir.createFile("captured.txt", .{});
+    const io = IOContext.captured(file.writer());
+    return .{ .f = file, .io = io };
+}
 
 test "create action" {
     const config = CreateAction.Config{
@@ -236,7 +271,10 @@ test "create action" {
     var ctx = try manage_main.makeTestContext();
     defer ctx.deinit();
 
-    var action = try CreateAction.init(&ctx, config);
+    const tio = try testIO();
+    defer tio.deinit();
+
+    var action = try CreateAction.init(&ctx, config, tio.io);
     defer action.deinit();
 
     try action.run();
@@ -262,7 +300,10 @@ test "create action (aliasing)" {
         .tag = "test tag2",
     };
 
-    var action = try CreateAction.init(&ctx, config);
+    const tio = try testIO();
+    defer tio.deinit();
+
+    var action = try CreateAction.init(&ctx, config, tio.io);
     defer action.deinit();
 
     try action.run();
@@ -1521,6 +1562,8 @@ pub fn main() anyerror!void {
     defer ctx.deinit();
     if (given_args.dry_run) try ctx.turnIntoMemoryDb();
 
+    const default_io = IOContext.system();
+
     errdefer ctx.logLastError();
     switch (action_config) {
         .Search => |search_config| {
@@ -1529,7 +1572,7 @@ pub fn main() anyerror!void {
             try self.run();
         },
         .Create => |create_config| {
-            var self = try CreateAction.init(&ctx, create_config);
+            var self = try CreateAction.init(&ctx, create_config, default_io);
             defer self.deinit();
             try self.run();
         },

--- a/src/tags_main.zig
+++ b/src/tags_main.zig
@@ -267,7 +267,7 @@ fn testIO() !TestIO {
     var tmp = std.testing.tmpDir(.{});
     // dont care about cleaning tmp
 
-    const file = try tmp.dir.createFile("captured.txt", .{});
+    const file = try tmp.dir.createFile("captured.txt", .{ .read = true });
     const io = IOContext.captured(file.writer());
     return .{ .f = file, .io = io };
 }
@@ -878,7 +878,7 @@ const RemoveParent = struct {
     }
 
     pub fn run(self: *Self) !void {
-        // parent_relationship is only used on that stdout) call as
+        // parent_relationship is only used on that stdout call as
         // information for the user, so it can't be tested until we have
         // stdout capturing.
         const parent_relationship = (try self.ctx.db.one(
@@ -997,7 +997,7 @@ test "remove parent (no entry deletion)" {
     var indexed_file = try ctx.createFileFromDir(tmp.dir, "test_file", .{});
     defer indexed_file.deinit();
 
-    const ids = try parentTestSetup(&ctx, &indexed_file, &tio.io);
+    const ids = try parentTestSetup(&ctx, &indexed_file, &tio);
 
     // attempt to run command with delete_file_entries = false
 
@@ -1043,7 +1043,7 @@ const ParentTestSetupResult = struct {
 fn parentTestSetup(
     ctx: *Context,
     indexed_file: *Context.File,
-    io: *IOContext,
+    tio: *TestIO,
 ) !ParentTestSetupResult {
     const child_tag = try ctx.createNamedTag("child_test_tag", "en", null, .{});
     try indexed_file.addTag(child_tag.core, .{});
@@ -1060,10 +1060,18 @@ fn parentTestSetup(
     try ctx.processTagTree(.{});
 
     // always run ListParent so that it compiles
-    // TODO write test for ListParent (capture stdout??)
-    var action = try ListParent.init(ctx, {}, io);
+    // TODO write test for ListParent (capture stdout from test io)
+    var action = try ListParent.init(ctx, {}, &tio.io);
     defer action.deinit();
     try action.run();
+
+    try tio.f.seekTo(0);
+    var buf: [8192]u8 = undefined;
+    const bytes = try tio.f.readAll(&buf);
+    const stdout_sent = buf[0..bytes];
+    try std.testing.expect(std.mem.containsAtLeast(u8, stdout_sent, 1, parent_tag.core.id.str()));
+    try std.testing.expect(std.mem.containsAtLeast(u8, stdout_sent, 1, parent_tag2.core.id.str()));
+    try std.testing.expect(std.mem.containsAtLeast(u8, stdout_sent, 1, parent_tag3.core.id.str()));
 
     return ParentTestSetupResult{
         .tag_tree_entry_id = tag_tree_entry_id,
@@ -1090,7 +1098,7 @@ test "remove parent (with entry deletion)" {
     var indexed_file = try ctx.createFileFromDir(tmp.dir, "test_file", .{});
     defer indexed_file.deinit();
 
-    const ids = try parentTestSetup(&ctx, &indexed_file, &tio.io);
+    const ids = try parentTestSetup(&ctx, &indexed_file, &tio);
 
     var args = Args{ .ask_confirmation = false };
     const config = RemoveParent.Config{

--- a/src/tags_main.zig
+++ b/src/tags_main.zig
@@ -1131,11 +1131,12 @@ const CreatePool = struct {
 
     ctx: *Context,
     config: Config,
+    io: *IOContext,
 
     const Self = @This();
 
-    pub fn init(ctx: *Context, config: Config) !Self {
-        return Self{ .ctx = ctx, .config = config };
+    pub fn init(ctx: *Context, config: Config, io: *IOContext) !Self {
+        return Self{ .ctx = ctx, .config = config, .io = io };
     }
 
     pub fn deinit(self: *Self) void {
@@ -1143,13 +1144,11 @@ const CreatePool = struct {
     }
 
     pub fn run(self: *Self) !void {
-        var stdout = std.io.getStdOut().writer();
-
         var pool = try self.ctx.createPool(self.config.title);
         defer pool.deinit();
 
-        std.debug.print("pool created with id ", .{});
-        try stdout.print("{d}\n", .{pool.hash});
+        std.debug.print("pool created with id {d}", .{pool.hash.id});
+        try self.io.stdout().print("{d}\n", .{pool.hash});
     }
 };
 
@@ -1170,11 +1169,12 @@ const FetchPool = struct {
 
     ctx: *Context,
     config: Config,
+    io: *IOContext,
 
     const Self = @This();
 
-    pub fn init(ctx: *Context, config: Config) !Self {
-        return Self{ .ctx = ctx, .config = config };
+    pub fn init(ctx: *Context, config: Config, io: *IOContext) !Self {
+        return Self{ .ctx = ctx, .config = config, .io = io };
     }
 
     pub fn deinit(self: *Self) void {
@@ -1182,15 +1182,13 @@ const FetchPool = struct {
     }
 
     pub fn run(self: *Self) !void {
-        var stdout = std.io.getStdOut().writer();
-
         var pool = (try self.ctx.fetchPool(self.config.pool_id)) orelse return error.PoolNotFound;
         defer pool.deinit();
 
         const file_hashes = try pool.fetchFiles(self.ctx.allocator);
         defer self.ctx.allocator.free(file_hashes);
 
-        try stdout.print(
+        try self.io.stdout().print(
             "pool '{s}' {s}\n",
             .{ pool.title, pool.hash },
         );
@@ -1199,9 +1197,9 @@ const FetchPool = struct {
             var file = (try self.ctx.fetchFile(file_hash.id)).?;
             defer file.deinit();
 
-            try stdout.print("- {s}", .{file.local_path});
-            try file.printTagsTo(self.ctx.allocator, stdout, .{});
-            try stdout.print("\n", .{});
+            try self.io.stdout().print("- {s}", .{file.local_path});
+            try file.printTagsTo(self.ctx.allocator, self.io.stdout(), .{});
+            try self.io.stdout().print("\n", .{});
         }
     }
 };
@@ -1221,11 +1219,12 @@ const SearchPool = struct {
 
     ctx: *Context,
     config: Config,
+    io: *IOContext,
 
     const Self = @This();
 
-    pub fn init(ctx: *Context, config: Config) !Self {
-        return Self{ .ctx = ctx, .config = config };
+    pub fn init(ctx: *Context, config: Config, io: *IOContext) !Self {
+        return Self{ .ctx = ctx, .config = config, .io = io };
     }
 
     pub fn deinit(self: *Self) void {
@@ -1233,8 +1232,6 @@ const SearchPool = struct {
     }
 
     pub fn run(self: *Self) !void {
-        var stdout = std.io.getStdOut().writer();
-
         var stmt = try self.ctx.db.prepare(
             \\ select pool_hash
             \\ from pools
@@ -1254,7 +1251,7 @@ const SearchPool = struct {
             var pool = (try self.ctx.fetchPool(ID.new(pool_hash))).?;
             defer pool.deinit();
 
-            try stdout.print(
+            try self.io.stdout().print(
                 "pool '{s}' {s}\n",
                 .{ pool.title, pool.hash },
             );
@@ -1277,11 +1274,12 @@ const RemovePool = struct {
 
     ctx: *Context,
     config: Config,
+    io: *IOContext,
 
     const Self = @This();
 
-    pub fn init(ctx: *Context, config: Config) !Self {
-        return Self{ .ctx = ctx, .config = config };
+    pub fn init(ctx: *Context, config: Config, io: *IOContext) !Self {
+        return Self{ .ctx = ctx, .config = config, .io = io };
     }
 
     pub fn deinit(self: *Self) void {
@@ -1289,12 +1287,10 @@ const RemovePool = struct {
     }
 
     pub fn run(self: *Self) !void {
-        var stdout = std.io.getStdOut().writer();
-
         var pool = (try self.ctx.fetchPool(self.config.pool_id)) orelse return error.PoolNotFound;
         defer pool.deinit();
 
-        try stdout.print(
+        try self.io.stdout().print(
             "pool '{s}' {s} will be removed\n",
             .{ pool.title, pool.hash },
         );
@@ -1323,11 +1319,12 @@ const CreateSource = struct {
 
     ctx: *Context,
     config: Config,
+    io: *IOContext,
 
     const Self = @This();
 
-    pub fn init(ctx: *Context, config: Config) !Self {
-        return Self{ .ctx = ctx, .config = config };
+    pub fn init(ctx: *Context, config: Config, io: *IOContext) !Self {
+        return Self{ .ctx = ctx, .config = config, .io = io };
     }
 
     pub fn deinit(self: *Self) void {
@@ -1335,11 +1332,9 @@ const CreateSource = struct {
     }
 
     pub fn run(self: *Self) !void {
-        var stdout = std.io.getStdOut().writer();
-
         const source = try self.ctx.createTagSource(self.config.title, .{});
-        std.debug.print("source created with id ", .{});
-        try stdout.print("{d}\n", .{source.id});
+        std.debug.print("source created with id {d}", .{source.id});
+        try self.io.stdout().print("{d}\n", .{source.id});
     }
 };
 
@@ -1357,11 +1352,12 @@ const RemoveSource = struct {
 
     ctx: *Context,
     config: Config,
+    io: *IOContext,
 
     const Self = @This();
 
-    pub fn init(ctx: *Context, config: Config) !Self {
-        return Self{ .ctx = ctx, .config = config };
+    pub fn init(ctx: *Context, config: Config, io: *IOContext) !Self {
+        return Self{ .ctx = ctx, .config = config, .io = io };
     }
 
     pub fn deinit(self: *Self) void {
@@ -1369,14 +1365,11 @@ const RemoveSource = struct {
     }
 
     pub fn run(self: *Self) !void {
-        var stdout = std.io.getStdOut().writer();
-
         const source =
             (try self.ctx.fetchTagSource(.external, self.config.id)) orelse return error.SourceNotFound;
 
         try source.delete();
-
-        try stdout.print("ok\n", .{});
+        try self.io.stdout().print("ok\n", .{});
     }
 };
 
@@ -1389,11 +1382,12 @@ const ListSource = struct {
 
     ctx: *Context,
     config: void,
+    io: *IOContext,
 
     const Self = @This();
 
-    pub fn init(ctx: *Context, config: void) !Self {
-        return Self{ .ctx = ctx, .config = config };
+    pub fn init(ctx: *Context, config: void, io: *IOContext) !Self {
+        return Self{ .ctx = ctx, .config = config, .io = io };
     }
 
     pub fn deinit(self: *Self) void {
@@ -1401,8 +1395,6 @@ const ListSource = struct {
     }
 
     pub fn run(self: *Self) !void {
-        const raw_stdout = std.io.getStdOut().writer();
-
         var stmt = try self.ctx.db.prepare(
             \\ select type, id, name
             \\ from tag_sources
@@ -1416,18 +1408,14 @@ const ListSource = struct {
             self.ctx.allocator.free(entries);
         }
 
-        const BufferedFileWriter = std.io.BufferedWriter(4096, std.fs.File.Writer);
-        var buffered_stdout = BufferedFileWriter{ .unbuffered_writer = raw_stdout };
-        var stdout = buffered_stdout.writer();
-
         for (entries) |row| {
-            try stdout.print(
+            try self.io.stdout().print(
                 "type={d} id={d}: name={s}\n",
                 .{ row.type, row.id, row.name },
             );
         }
 
-        try buffered_stdout.flush();
+        try self.io.flushStdout();
     }
 };
 
@@ -1613,38 +1601,38 @@ pub fn main() anyerror!void {
         },
 
         .CreatePool => |config| {
-            var self = try CreatePool.init(&ctx, config);
+            var self = try CreatePool.init(&ctx, config, &default_io);
             defer self.deinit();
             try self.run();
         },
         .FetchPool => |config| {
-            var self = try FetchPool.init(&ctx, config);
+            var self = try FetchPool.init(&ctx, config, &default_io);
             defer self.deinit();
             try self.run();
         },
         .SearchPool => |config| {
-            var self = try SearchPool.init(&ctx, config);
+            var self = try SearchPool.init(&ctx, config, &default_io);
             defer self.deinit();
             try self.run();
         },
         .RemovePool => |config| {
-            var self = try RemovePool.init(&ctx, config);
+            var self = try RemovePool.init(&ctx, config, &default_io);
             defer self.deinit();
             try self.run();
         },
 
         .CreateSource => |config| {
-            var self = try CreateSource.init(&ctx, config);
+            var self = try CreateSource.init(&ctx, config, &default_io);
             defer self.deinit();
             try self.run();
         },
         .ListSource => |config| {
-            var self = try ListSource.init(&ctx, config);
+            var self = try ListSource.init(&ctx, config, &default_io);
             defer self.deinit();
             try self.run();
         },
         .RemoveSource => |config| {
-            var self = try RemoveSource.init(&ctx, config);
+            var self = try RemoveSource.init(&ctx, config, &default_io);
             defer self.deinit();
             try self.run();
         },


### PR DESCRIPTION
problem is that from the new test runner protocol (around 0.12 or 0.13? don't remember) the tests started freezing, i hid it and instead ran the test binary directly, manually, as removing `--listen=-` made the tests work. after debugging it now (due to general zig 0.14 porting) it turns out that the protocol runs on stdin/stdout, and `atags` tests involve actually invoking the CLI utility code which will write to stdout.

to properly fix this we need to route stdout to somewhere else, done here via an "IOContext" but i may move that to `Context.IOContext` in the future so that all utilities can use this kind of code

in turn, `zig build test` can be finally re-enabled on CI without freezing